### PR TITLE
move require functions into cheovim.lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,2 +1,1 @@
 require("cheovim")
-require("cheovim.functions")

--- a/lua/cheovim.lua
+++ b/lua/cheovim.lua
@@ -1,4 +1,5 @@
 -- Initialize the loader
+require("cheovim.functions")
 local loader = require("cheovim.loader")
 
 -- Grab the selected profiles from the profiles file


### PR DESCRIPTION
Fixes #21 

moves the require functions call from `init.lua` into `cheovim.lua`
